### PR TITLE
Add null-safety to "type" check.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,17 @@ export default function preserveDirectives({
     transform(code) {
       const ast = this.parse(code) as ExtendedAcornNode;
 
-      if (ast.type === "Program") {
+      if (ast.type === "Program" && ast.body) {
         const directives: string[] = [];
         let i = 0;
 
-        while (ast.body?.[i]?.type === "ExpressionStatement") {
-          const node = ast.body[i];
+        // Nodes in body should never be falsy, but issue #5 tells us otherwise
+        // so just in case we filter them out here
+        const filteredBody = ast.body.filter(Boolean);
+
+        // .type must be defined according to the spec, but just in case..
+        while (filteredBody[i]?.type === "ExpressionStatement") {
+          const node = filteredBody[i];
           if (node.directive) {
             directives.push(node.directive);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export default function preserveDirectives({
         const directives: string[] = [];
         let i = 0;
 
-        while (ast.body?.[i].type === "ExpressionStatement") {
+        while (ast.body?.[i]?.type === "ExpressionStatement") {
           const node = ast.body[i];
           if (node.directive) {
             directives.push(node.directive);


### PR DESCRIPTION
Fixes "TypeError: Cannot read properties of undefined (reading 'type')" (https://github.com/Ephem/rollup-plugin-preserve-directives/issues/5)