### PR TITLE
fix: Skip parsing CSS files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export function preserveDirectives({
     name: "preserve-directives",
     // Capture directives metadata during the transform phase
     transform(code, id) {
+      // this.parse() does not work on CSS files
       if (!id.endsWith('.css')) {
         const ast = this.parse(code);
         if (ast.type === "Program" && ast.body) {


### PR DESCRIPTION
When building a Vue project, the Vue plugin splits `.vue` files into JS and CSS files. When this plugin tries to transform the CSS files, it throws this error:

```
[preserve-directives] Expression expected
file: /home/runner/work/config/config/integrations/vue/src/App.vue?vue&type=style&index=0&scoped=57d0a178&lang.css
error during build:
RollupError: Expression expected
    at error (file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/parseAst.js:337:30)
    at nodeConverters (file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/parseAst.js:2084:9)
    at convertNode (file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/parseAst.js:969:12)
    at convertProgram (file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/parseAst.js:960:48)
    at Object.parseAst [as parse] (file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/parseAst.js:2144:20)
    at Object.transform (file:///home/runner/work/config/config/node_modules/.pnpm/rollup-plugin-preserve-directives@0.3.0_rollup@4.9.2/node_modules/rollup-plugin-preserve-directives/dist/index.js:11:24)
    at file:///home/runner/work/config/config/node_modules/.pnpm/rollup@4.9.2/node_modules/rollup/dist/es/shared/node-entry.js:18642:40
```

Note this issue also occurs for plain old CSS files.

I've debugged this and found specifically that it is `this.parse(code)` that causes the error. This PR checks if the file it is about to transform has the extension `.css`, and if so, skips parsing.

Fixes an issue in https://github.com/TanStack/config/pull/25