### PR TITLE
Let user add file types to ignore when parsing (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Let user add file types to ignore when parsing (#21).
+- Support include and exclude options (#21).
 
 ## [0.3.1] - 2024-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Let user add file types to ignore when parsing (#21).
+
 ## [0.3.1] - 2024-01-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ export default {
 
 This can be useful when you have a common list of plugins for several builds, where some have `preserveModules: false` and some `true`.
 
-### Skip parsing for specific file types
+### Include / exclude
 
-Some files, like CSS, cannot be parsed for directives. If you want to skip parsing for specific file types, you can pass an array of file extensions to skip. CSS files are skipped by default:
+To exclude certain files from being processed by this plugin, you can use the `include` and `exclude` options. These options take [minimatch globs](https://github.com/motemen/minimatch-cheat-sheet), and can be used like this:
 
 ```js
 import preserveDirectives from "rollup-plugin-preserve-directives";
@@ -70,7 +70,7 @@ export default {
   output: {
     preserveModules: true,
   },
-  plugins: [preserveDirectives({ fileTypesToSkip: ["scss", "pcss"] })],
+  plugins: [preserveDirectives({ exclude: ["**/*.scss", "**/*.pcss"] })],
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ export default {
 
 This can be useful when you have a common list of plugins for several builds, where some have `preserveModules: false` and some `true`.
 
+### Skip parsing for specific file types
+
+Some files, like CSS, cannot be parsed for directives. If you want to skip parsing for specific file types, you can pass an array of file extensions to skip. CSS files are skipped by default:
+
+```js
+import preserveDirectives from "rollup-plugin-preserve-directives";
+
+export default {
+  output: {
+    preserveModules: true,
+  },
+  plugins: [preserveDirectives({ fileTypesToSkip: ["scss", "pcss"] })],
+};
+```
+
 ## Motivation and usecase
 
 While this plugin is generic and works with any directive, the motivator was to be able to build libraries that wants to provide both React Server Components and Client Components without having to use separate entrypoints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
         "magic-string": "^0.30.5"
       },
       "devDependencies": {
@@ -471,6 +472,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
@@ -643,8 +665,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -857,6 +878,11 @@
         "@esbuild/win32-ia32": "0.19.11",
         "@esbuild/win32-x64": "0.19.11"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -1302,7 +1328,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -1418,7 +1443,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
       "integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -1942,6 +1967,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
@@ -2036,8 +2071,7 @@
     "@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -2194,6 +2228,11 @@
         "@esbuild/win32-ia32": "0.19.11",
         "@esbuild/win32-x64": "0.19.11"
       }
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "execa": {
       "version": "5.1.1",
@@ -2528,8 +2567,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pirates": {
       "version": "4.0.5",
@@ -2584,7 +2622,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
       "integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.9.5",
         "@rollup/rollup-android-arm64": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "rollup": "2.x || 3.x || 4.x"
   },
   "dependencies": {
+    "@rollup/pluginutils": "^5.1.0",
     "magic-string": "^0.30.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ type PreserveDirectivesOptions = {
  *
  * @param {Object} options - Plugin options
  * @param {boolean} options.suppressPreserveModulesWarning - Disable the warning when preserveModules is false
- * @param {string[]} options.skipFileTypes - File types to skip from parsing
+ * @param {string[]} options.fileTypesToSkip - File types to skip from parsing
  *
  */
 


### PR DESCRIPTION
Added option, skipFileTypes, to let users add an array of file types to skip from parsing. Still skipping .css files by default.

Have tested this is my project, and can confirm that it works for .scss files.

Have added changelog entry in CHANGELOG, and documentation in README.

Note: returning null early from transform function, if file type should be ignored, instead of wrapping the whole function in an if statement.

Closes #21 